### PR TITLE
Add Rest Countries demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ This app is built using Appsmith. Turn any datasource into an internal app in mi
 
 ![](https://raw.githubusercontent.com/appsmithorg/appsmith/release/static/images/integrations.png)
 
+### Demo Setup Using the Rest Countries API
+
+The repository now includes the JSON files required to load a simple Appsmith
+application.  The app contains:
+
+1. A REST API datasource configured at `https://restcountries.com`.
+2. A query named **GetCountries** that calls `/v3.1/all` and runs on page load.
+3. A page with a **Table** widget bound to `{{ GetCountries.data }}`.
+4. A **List** widget that displays each country's flag and name using Image and
+   Text widgets.
+
+Importing this repository into Appsmith will create the demo automatically so you
+can explore the API without any manual setup.
+
+
 ### [Github](https://github.com/appsmithorg/appsmith) • [Docs](https://docs.appsmith.com/?utm_source=github&utm_medium=social&utm_content=appsmith_docs&utm_campaign=null&utm_term=appsmith_docs) • [Community](https://community.appsmith.com/) • [Tutorials](https://github.com/appsmithorg/appsmith/tree/update/readme#tutorials) • [Youtube](https://www.youtube.com/appsmith) • [Discord](https://discord.gg/rBTTVJp)
 
 ##### You can visit the application using the below link

--- a/datasources/RestCountries.json
+++ b/datasources/RestCountries.json
@@ -1,0 +1,7 @@
+{
+  "name": "RestCountriesAPI",
+  "pluginId": "restapi-plugin",
+  "datasourceConfiguration": {
+    "url": "https://restcountries.com"
+  }
+}

--- a/pages/Page1/Page1.json
+++ b/pages/Page1/Page1.json
@@ -22,6 +22,48 @@
           "type": "CANVAS_WIDGET",
           "version": 93,
           "widgetId": "0",
+          "children": [
+            {
+              "widgetName": "Table1",
+              "type": "TABLE_WIDGET",
+              "widgetId": "table1",
+              "topRow": 0,
+              "bottomRow": 20,
+              "leftColumn": 0,
+              "rightColumn": 24,
+              "parentId": "0",
+              "tableData": "{{ GetCountries.data }}",
+              "dynamicBindingPathList": [ { "key": "tableData" } ]
+            },
+            {
+              "widgetName": "List1",
+              "type": "LIST_WIDGET",
+              "widgetId": "list1",
+              "topRow": 21,
+              "bottomRow": 45,
+              "leftColumn": 0,
+              "rightColumn": 24,
+              "parentId": "0",
+              "listData": "{{ GetCountries.data }}",
+              "dynamicBindingPathList": [ { "key": "listData" } ],
+              "children": [
+                {
+                  "widgetName": "Image1",
+                  "type": "IMAGE_WIDGET",
+                  "widgetId": "image1",
+                  "image": "{{ currentItem.flags.png }}",
+                  "dynamicBindingPathList": [ { "key": "image" } ]
+                },
+                {
+                  "widgetName": "Text1",
+                  "type": "TEXT_WIDGET",
+                  "widgetId": "text1",
+                  "text": "{{ currentItem.name.common }}",
+                  "dynamicBindingPathList": [ { "key": "text" } ]
+                }
+              ]
+            }
+          ],
           "widgetName": "MainContainer"
         }
       }

--- a/queries/GetCountries.json
+++ b/queries/GetCountries.json
@@ -1,0 +1,11 @@
+{
+  "name": "GetCountries",
+  "datasource": {
+    "name": "RestCountriesAPI"
+  },
+  "actionConfiguration": {
+    "httpMethod": "GET",
+    "path": "/v3.1/all"
+  },
+  "executeOnLoad": true
+}


### PR DESCRIPTION
## Summary
- update README to describe prebuilt demo app
- create datasource and query JSON for Rest Countries API
- define table and list widgets in Page1

## Testing
- `python -m json.tool pages/Page1/Page1.json`
- `git status --short`
